### PR TITLE
Feature: Module migration create from stub

### DIFF
--- a/src/Console/MakeMigrationCommand.php
+++ b/src/Console/MakeMigrationCommand.php
@@ -24,11 +24,11 @@ class MakeMigrationCommand extends Command
         $this->moduleName = Str::studly($this->argument('moduleName'));
         $this->migrationName = $this->argument('migrationName');
 
-        if (! $this->moduleExists()) {
+        if (!$this->moduleExists()) {
             return self::FAILURE;
         }
 
-        $this->comment('Module '.$this->moduleName.' found, creating migration file...');
+        $this->comment('Module ' . $this->moduleName . ' found, creating migration file...');
         $this->createMigrationFile();
 
         return self::SUCCESS;
@@ -38,9 +38,21 @@ class MakeMigrationCommand extends Command
     {
         (new Filesystem)->ensureDirectoryExists(base_path("modules/{$this->moduleName}/Database/Migrations"));
 
-        $this->call('make:migration', [
-            'name' => $this->migrationName,
-            '--path' => "modules/{$this->moduleName}/Database/Migrations",
-        ]);
+        /** Run Laravels default migration command */
+        // $this->call('make:migration', [
+        //     'name' => $this->migrationName,
+        //     '--path' => "modules/{$this->moduleName}/Database/Migrations",
+        // ]);
+
+        /** Create migration according to stub */
+        $stub = file_get_contents(__DIR__ . '/../../stubs/module-stub/modules/Database/Migrations/create_table.stub');
+
+        $tableName = strtolower(Str::plural($this->moduleName));
+
+        $stub = str_replace('{{ tableName }}', $tableName, $stub);
+
+        $path = base_path("modules/{$this->moduleName}/Database/Migrations/" . date('Y_m_d_His_') . "create_{$tableName}_table.php");
+
+        file_put_contents($path, $stub);
     }
 }

--- a/stubs/module-stub/modules/Database/Migrations/create_table.stub
+++ b/stubs/module-stub/modules/Database/Migrations/create_table.stub
@@ -11,11 +11,12 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('${{ resourceName }}', function (Blueprint $table) {
-            // $table->id();
-            // $table->string('name');
-            // $table->timestamps();
-            // $table->softDeletes();
+        Schema::create('{{ tableName }}', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+
+            $table->timestamps();
+            $table->softDeletes();
         });
     }
 
@@ -24,6 +25,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('${{ resourceName }}');
+        Schema::dropIfExists('{{ tableName }}');
     }
 };

--- a/stubs/module-stub/modules/Http/Controllers/ModuleController.stub
+++ b/stubs/module-stub/modules/Http/Controllers/ModuleController.stub
@@ -18,8 +18,8 @@ class {{ ResourceName }}Controller extends BackendController
             ->withQueryString()
             ->through(fn (${{ resourceName }}) => [
                     'id' => ${{ resourceName }}->id,
-                    // 'name' => ${{ resourceName }}->name,
-                    'created_at' => ${{ resourceName }}->created_at->format('d/m/Y H:i') . 'h'
+                    'name' => ${{ resourceName }}->name,
+                    'created_at' => ${{ resourceName }}->created_at
             ]);
 
         return inertia('{{ ModuleName }}/{{ ResourceName }}Index', [

--- a/stubs/module-stub/modules/Http/Requests/ModuleValidate.stub
+++ b/stubs/module-stub/modules/Http/Requests/ModuleValidate.stub
@@ -9,7 +9,7 @@ class {{ ResourceName }}Validate extends Request
     public function rules(): array
     {
         return [
-            // 'name' => 'required',
+            'name' => ['required', 'string', 'max:255'],
         ];
     }
 }

--- a/stubs/module-stub/modules/Models/Model.stub
+++ b/stubs/module-stub/modules/Models/Model.stub
@@ -6,10 +6,21 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Modules\Support\Models\BaseModel;
 use Modules\Support\Traits\Searchable;
 use Modules\Support\Traits\ActivityLog;
+use Carbon\Carbon;
 
 class {{ ResourceName }} extends BaseModel
 {
     use ActivityLog, Searchable, SoftDeletes;
-    
+
     protected $table = '{{ resourceName }}s';
+
+    public function getCreatedAtAttribute()
+    {
+        return Carbon::parse($this->attributes['created_at'])->isoFormat('D MMMM Y HH:mm');
+    }
+
+    public function getUpdatedAtAttribute()
+    {
+        return Carbon::parse($this->attributes['updated_at'])->isoFormat('D MMMM Y HH:mm');
+    }
 }

--- a/stubs/page-stub/Index.stub
+++ b/stubs/page-stub/Index.stub
@@ -27,9 +27,13 @@
                         {{ item.id }}
                     </AppDataTableData>
 
-                    <!-- <AppDataTableData>
+                    <AppDataTableData>
                         {{ item.name }}
-                    </AppDataTableData> -->
+                    </AppDataTableData>
+
+                    <AppDataTableData>
+                        {{ item.created_at }}
+                    </AppDataTableData>
 
                     <AppDataTableData>
                         <!-- edit {{ resourceName }} -->
@@ -98,7 +102,7 @@ const breadCrumb = [
   { label: '{{ ResourceName }}s', last: true }
 ]
 
-const headers = ['ID', 'Actions']
+const headers = ['ID', 'Name', 'Created at', 'Actions']
 
 const confirmDialogRef = ref(null)
 const confirmDelete = (deleteRoute) => {


### PR DESCRIPTION
Currently module (create table) migration is run by Laravel's default migration command. Although stub is present but it is not being used. I have used the stub file with dynamic file name with timestamp according to laravel rule. softDeletes() is used by default. Using stub we can create table with a default column 'name'. 

A default column 'name' will help make a complete CRUD operation without much hassle. Proper validation for 'name' column is added in request validate file. and shown in vue component. 


I have formatted created_at and updated_at column using Carbon in Model file. From now on this columns can be used anywhere directly without formatting

Name and Created At field show in UI