### PR TITLE
Feature: AppImageNotAvailable Vue Component Added to Misc

### DIFF
--- a/stubs/resources/js/Components/Misc/AppImageNotAvailable.vue
+++ b/stubs/resources/js/Components/Misc/AppImageNotAvailable.vue
@@ -1,0 +1,7 @@
+<template>
+    <div
+        class="flex h-10 w-10 items-center justify-center rounded bg-gradient-to-bl from-skin-neutral-3 to-skin-neutral-6"
+    >
+        <span class="text-xs text-skin-neutral-9">N/A</span>
+    </div>
+</template>


### PR DESCRIPTION
**Summary:**
The AppImageNotAvailable component was previously only available within the Blog Module. This limitation meant that the component could not be utilized if the Blog Module was not installed. However, there are scenarios where displaying a thumbnail in the application is necessary even when an image is not available.

**Enhancement:**
This update makes the AppImageNotAvailable component available for use independently of the Blog Module. It can now be utilized across the application, regardless of the Blog Module's installation status.

- The AppImageNotAvailable component can now be used in any part of the application.
- Ensures that a placeholder image is displayed when an image is unavailable, enhancing the user experience.