### PR TITLE
Fix: Permission Validation error while updating same permission

### DIFF
--- a/stubs/modules/Acl/Http/Requests/PermissionValidate.php
+++ b/stubs/modules/Acl/Http/Requests/PermissionValidate.php
@@ -2,6 +2,8 @@
 
 namespace Modules\Acl\Http\Requests;
 
+use Illuminate\Validation\Rule;
+use Spatie\Permission\Models\Permission;
 use Modules\Support\Http\Requests\Request;
 
 class PermissionValidate extends Request
@@ -15,7 +17,11 @@ class PermissionValidate extends Request
     {
         return [
 
-            'name' => 'required|min:3|unique:permissions,name',
+            'name' => [
+                'required',
+                'min:3',
+                Rule::unique(Permission::class)->ignore($this->id),
+            ]
             // 'guard_name' => 'required'
 
         ];


### PR DESCRIPTION
While updating a permission name , it is getting error ' this permission already exist'. The unique validation rule should except same permission while updating. This PR fixed this. 